### PR TITLE
Add configurable multi-entity alarms (discussion #16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-08-04
+
+### Added
+- `alarms:` — a list of alarms replacing the single pulsating alarm. Each alarm can watch **any entity**, not only the gauge entity, which removes the need for `config-template-card` wrappers ([discussion #16](https://github.com/guiohm79/custom-gauge-card/discussions/16))
+- 8 alarm conditions: `range`, `outside`, `above`, `below`, `equal`, `state`, `state_not`, `unavailable`
+- 4 alarm effects: `shadow_pulse` (the former behavior), `leds_blink`, `value_blink`, `border_pulse`
+- Per-alarm `color`, `duration`, `intensity`, `attribute` and `name`
+- Several alarms can be active at the same time, one per effect
+- Visual editor — the "Pulsating alarm" section becomes "Alarms", with add/remove rows and condition-dependent fields
+
+### Changed
+- `shadow_pulse` no longer requires `center_shadow: true` — with the center shadow off, the shadow now appears only while the alarm is active (it used to stay visible permanently in that configuration)
+- Alarms are evaluated on every state update, bypassing `debounce_updates`, so an alert is never delayed
+- Alarm effects are dropped while the card is off-screen under `power_save_mode`
+
+### Fixed
+- The pulsating shadow never reached its target color: the 300 ms CSS transition on `.center-shadow` lagged behind the 16 ms pulse tick. Only visible now that an alarm can define its own color, but the transition was fighting the pulse all along
+- `hexToRgba()` accepts `#rgb` shorthand and no longer produces `rgba(NaN,…)` on unexpected color notations
+
+### Deprecated
+- `center_shadow_pulse`, `center_shadow_pulse_min`, `center_shadow_pulse_max`, `center_shadow_pulse_duration`, `center_shadow_pulse_intensity` — still fully supported, silently converted into a single alarm. `alarms:` takes precedence when both are present
+
 ## [2.0.0] - 2026-05-29
 
 ### Added
@@ -99,6 +121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Example configuration in card.yaml
 - Screenshot (Capture1.png)
 
+[2.2.0]: https://github.com/guiohm79/custom-gauge-card/compare/v2.0.0...v2.2.0
 [2.0.0]: https://github.com/guiohm79/custom-gauge-card/compare/v1.0.4...v2.0.0
 [1.0.4]: https://github.com/guiohm79/custom-gauge-card/compare/v1.0.3.1...v1.0.4
 [1.0.3.1]: https://github.com/guiohm79/custom-gauge-card/compare/v1.0.3...v1.0.3.1

--- a/README.fr.md
+++ b/README.fr.md
@@ -21,6 +21,7 @@ Une carte personnalisée pour Home Assistant qui affiche vos capteurs sous forme
 - Jauge circulaire avec LEDs animées
 - Transitions fluides et douces entre les valeurs
 - Effets d'ombre et de lumière dynamiques
+- Alarmes multi-entités avec quatre effets visuels (ombre pulsante, LEDs clignotantes, valeur clignotante, bordure pulsante)
 - Thèmes personnalisables (clair, sombre, personnalisé)
 
  **Zones et Marqueurs**
@@ -127,6 +128,20 @@ enable_shadow: true
 center_shadow: true
 center_shadow_blur: 30
 center_shadow_spread: 5
+
+# Alarmes (v2.2) — n'importe quelle entité, n'importe quel effet
+alarms:
+  - condition: range                  # alarme tant que 0L <= valeur <= 750L
+    min: 0
+    max: 750
+    effect: shadow_pulse
+    duration: 1500                    # durée d'un cycle en ms
+    intensity: 0.3                    # creux du cycle (30% à 100%)
+  - entity: binary_sensor.defaut_pompe  # surveille une tout autre entité
+    condition: state
+    state: "on"
+    effect: border_pulse
+    color: "#f44336"
 
 # Tendance
 show_trend: true
@@ -328,6 +343,129 @@ unit_font_weight: 600
 | `center_shadow` | boolean | false | Activer l'ombre au centre |
 | `center_shadow_blur` | number | 30 | Flou de l'ombre centrale |
 | `center_shadow_spread` | number | 15 | Expansion de l'ombre centrale |
+
+### Alarmes (v2.2)
+
+Une alarme surveille une entité et applique un effet visuel tant que sa condition est remplie.
+L'entité surveillée **n'est pas forcément celle de la jauge** : c'est ce qui permet, par exemple,
+de faire clignoter une jauge de batterie en fonction d'un `sensor.battery_power` séparé, sans
+passer par `config-template-card`.
+
+```yaml
+alarms:
+  - entity: sensor.battery_power   # optionnel — par défaut, l'entité de la jauge
+    condition: below
+    value: 0
+    effect: shadow_pulse
+    color: "#f44336"
+    duration: 900
+    intensity: 0.3
+```
+
+Plusieurs alarmes peuvent être actives simultanément, à condition d'utiliser des effets différents.
+
+| Option | Type | Défaut | Description |
+|--------|------|--------|-------------|
+| `entity` | string | entité de la jauge | Entité surveillée |
+| `attribute` | string | – | Lire cet attribut au lieu de l'état |
+| `condition` | string | `range` | Voir le tableau des conditions |
+| `min` / `max` | number | `min`/`max` de la jauge | Bornes pour `range` et `outside` |
+| `value` | number | 0 | Seuil pour `above`, `below`, `equal` |
+| `state` | string | `on` | Chaîne comparée pour `state` et `state_not` |
+| `effect` | string | `shadow_pulse` | Voir le tableau des effets |
+| `color` | string | couleur severity | Couleur de l'alarme — ignorée par `leds_blink` |
+| `duration` | number | 1000 | Durée d'un cycle complet en ms (minimum 100) |
+| `intensity` | number | 0.5 | Creux du cycle, 0 = flash complet, 1 = pulsation invisible |
+| `name` | string | – | Libellé affiché dans l'éditeur visuel uniquement |
+
+**Conditions**
+
+| `condition` | Se déclenche quand |
+|-------------|--------------------|
+| `range` | la valeur est comprise entre `min` et `max`, bornes incluses — défaut |
+| `outside` | la valeur est sous `min` ou au-dessus de `max` |
+| `above` | la valeur est strictement supérieure à `value` |
+| `below` | la valeur est strictement inférieure à `value` |
+| `equal` | la valeur est égale à `value` |
+| `state` | l'état est égal à `state` |
+| `state_not` | l'état est différent de `state` |
+| `unavailable` | l'entité est absente, `unavailable` ou `unknown` |
+
+Les conditions numériques ne se déclenchent jamais sur un état non numérique ou indisponible.
+
+**Effets**
+
+| `effect` | Résultat |
+|----------|----------|
+| `shadow_pulse` | L'ombre centrale pulse. Fonctionne aussi avec `center_shadow: false` — l'ombre n'apparaît alors que pendant l'alarme |
+| `leds_blink` | Les LEDs allumées clignotent en conservant leurs couleurs severity |
+| `value_blink` | La valeur centrale et l'unité clignotent, teintées avec `color` |
+| `border_pulse` | Un halo coloré pulse autour de toute la carte |
+
+Exemples :
+
+```yaml
+# Clignoter tant qu'un capteur de puissance séparé est en décharge
+alarms:
+  - entity: sensor.battery_power
+    condition: below
+    value: 0
+    effect: leds_blink
+    duration: 700
+
+# Mettre la carte en évidence tant qu'un détecteur de fuite est actif
+alarms:
+  - entity: binary_sensor.fuite_eau
+    condition: state
+    state: "on"
+    effect: border_pulse
+    color: "#f44336"
+
+# Deux alarmes sur une même carte : avertissement puis critique
+alarms:
+  - condition: range
+    min: 28
+    max: 32
+    effect: value_blink
+    color: "#ff9800"
+  - condition: above
+    value: 32
+    effect: shadow_pulse
+    color: "#f44336"
+    duration: 600
+    intensity: 0.15
+
+# Alerter quand le capteur ne remonte plus rien
+alarms:
+  - condition: unavailable
+    effect: value_blink
+    color: "#9e9e9e"
+    duration: 2000
+```
+
+**Migration depuis `center_shadow_pulse`**
+
+Les anciennes clés continuent de fonctionner : elles sont converties en une alarme unique, donc
+aucune configuration existante ne casse. `alarms:` a la priorité si les deux sont présentes, et
+modifier la section Alarmes dans l'éditeur visuel réécrit les anciennes clés au nouveau format.
+
+```yaml
+# Avant (toujours supporté)
+center_shadow_pulse: true
+center_shadow_pulse_min: 0
+center_shadow_pulse_max: 750
+center_shadow_pulse_duration: 1500
+center_shadow_pulse_intensity: 0.3
+
+# Après
+alarms:
+  - condition: range
+    min: 0
+    max: 750
+    effect: shadow_pulse
+    duration: 1500
+    intensity: 0.3
+```
 
 ### Transparence des Arrière-plans
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ A custom card for Home Assistant that displays your sensors as an animated and i
 
 
 
+## What's new in v2.2
+
+- **Alarms** — `alarms:` replaces the single `center_shadow_pulse`: any number of alarms, each watching **any entity** (not just the gauge one), with 8 condition types (`range`, `outside`, `above`, `below`, `equal`, `state`, `state_not`, `unavailable`) and 4 visual effects (`shadow_pulse`, `leds_blink`, `value_blink`, `border_pulse`), plus a per-alarm color. See [Alarms](#alarms-v22)
+- **Backward compatible** — existing `center_shadow_pulse*` configurations keep working unchanged
+
 ## What's new in v2
 
 - **Arc control** — `arc_sweep` (30–360°) and `arc_start` give you full YAML control over the arc span and start angle
@@ -60,7 +65,7 @@ A custom card for Home Assistant that displays your sensors as an animated and i
 - Circular gauge with animated LEDs
 - Smooth and fluid value transitions
 - Dynamic shadow and lighting effects
-- Pulsating center shadow alarm for visual alerts
+- Multi-entity alarms with four visual effects (pulsating shadow, blinking LEDs, blinking value, pulsating card border)
 - **Bidirectional display** for thermometer-style visualization with negative values
 - Customizable themes (light, dark, custom)
 - Configurable arc span and start angle (`arc_sweep`, `arc_start`)
@@ -194,12 +199,19 @@ center_shadow: true
 center_shadow_blur: 30
 center_shadow_spread: 5
 
-# Pulsating alarm (NEW feature)
-center_shadow_pulse: true           # Enable pulsation alarm
-center_shadow_pulse_duration: 1500  # Duration of one cycle in ms
-center_shadow_pulse_min: 0          # Alarm when value >= 0L (real sensor value)
-center_shadow_pulse_max: 750        # Alarm when value <= 750L (real sensor value)
-center_shadow_pulse_intensity: 0.3  # Minimum intensity (0.3 = 30% to 100%)
+# Alarms (v2.2) — any entity, any effect
+alarms:
+  - condition: range                # alarm while 0L <= value <= 750L
+    min: 0
+    max: 750
+    effect: shadow_pulse
+    duration: 1500                  # one cycle, in ms
+    intensity: 0.3                  # trough of the cycle (30% to 100%)
+  - entity: binary_sensor.pump_fault  # watch another entity entirely
+    condition: state
+    state: "on"
+    effect: border_pulse
+    color: "#f44336"
 
 # Trend
 show_trend: true
@@ -563,11 +575,143 @@ max: 40              # Maximum value
 | `center_shadow` | boolean | false | Enable center shadow |
 | `center_shadow_blur` | number | 30 | Center shadow blur |
 | `center_shadow_spread` | number | 15 | Center shadow spread |
-| `center_shadow_pulse` | boolean | false | **NEW:** Enable pulsation alarm on center shadow |
-| `center_shadow_pulse_duration` | number | 1000 | Duration of one complete pulsation cycle in ms |
-| `center_shadow_pulse_min` | number | `min` | Minimum value of alarm zone (uses real sensor values, not percentages) |
-| `center_shadow_pulse_max` | number | `max` | Maximum value of alarm zone (uses real sensor values, not percentages) |
-| `center_shadow_pulse_intensity` | number | 0.5 | Minimum intensity during pulsation (0-1) |
+| `center_shadow_pulse` | boolean | false | *Deprecated in v2.2 — see [Alarms](#alarms-v22).* Enable pulsation alarm on center shadow |
+| `center_shadow_pulse_duration` | number | 1000 | *Deprecated.* Duration of one complete pulsation cycle in ms |
+| `center_shadow_pulse_min` | number | `min` | *Deprecated.* Minimum value of alarm zone (uses real sensor values, not percentages) |
+| `center_shadow_pulse_max` | number | `max` | *Deprecated.* Maximum value of alarm zone (uses real sensor values, not percentages) |
+| `center_shadow_pulse_intensity` | number | 0.5 | *Deprecated.* Minimum intensity during pulsation (0-1) |
+
+### Alarms (v2.2)
+
+An alarm watches an entity and applies a visual effect for as long as its condition is met.
+The watched entity **does not have to be the gauge entity** — this is what makes it possible to,
+say, flash a battery gauge based on a separate `sensor.battery_power` value, without
+`config-template-card`.
+
+```yaml
+alarms:
+  - entity: sensor.battery_power   # optional — defaults to the gauge entity
+    condition: below
+    value: 0
+    effect: shadow_pulse           # see the effect list below
+    color: "#f44336"
+    duration: 900
+    intensity: 0.3
+```
+
+Several alarms can be active at once, as long as they use different effects.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `entity` | string | gauge entity | Entity to watch |
+| `attribute` | string | – | Read this attribute instead of the state |
+| `condition` | string | `range` | See the condition table below |
+| `min` / `max` | number | gauge `min`/`max` | Bounds for `range` and `outside` |
+| `value` | number | 0 | Threshold for `above`, `below`, `equal` |
+| `state` | string | `on` | Compared string for `state` and `state_not` |
+| `effect` | string | `shadow_pulse` | See the effect table below |
+| `color` | string | severity color | Alarm color — ignored by `leds_blink` |
+| `duration` | number | 1000 | One full cycle, in ms (minimum 100) |
+| `intensity` | number | 0.5 | Trough of the cycle, 0 = full flash, 1 = no visible pulse |
+| `name` | string | – | Label shown in the visual editor only |
+
+**Conditions**
+
+| `condition` | Fires when |
+|-------------|------------|
+| `range` | the reading is between `min` and `max`, bounds included — the default |
+| `outside` | the reading is below `min` or above `max` |
+| `above` | the reading is strictly greater than `value` |
+| `below` | the reading is strictly lower than `value` |
+| `equal` | the reading equals `value` |
+| `state` | the state string equals `state` |
+| `state_not` | the state string differs from `state` |
+| `unavailable` | the entity is missing, `unavailable` or `unknown` |
+
+Numeric conditions never fire on a non-numeric or unavailable state.
+
+**Effects**
+
+| `effect` | Result |
+|----------|--------|
+| `shadow_pulse` | The center shadow pulses. Works with `center_shadow: false` too — the shadow then only appears while the alarm is active |
+| `leds_blink` | The lit LEDs blink, keeping their severity colors |
+| `value_blink` | The center value and unit blink, tinted with `color` |
+| `border_pulse` | A colored halo pulses around the whole card |
+
+Examples:
+
+```yaml
+# Flash the gauge while a separate power sensor is discharging
+alarms:
+  - entity: sensor.battery_power
+    condition: below
+    value: 0
+    effect: leds_blink
+    duration: 700
+
+# Highlight the card while a leak detector is on
+alarms:
+  - entity: binary_sensor.water_leak
+    condition: state
+    state: "on"
+    effect: border_pulse
+    color: "#f44336"
+
+# Two alarms on one card: warning then critical
+alarms:
+  - condition: range
+    min: 28
+    max: 32
+    effect: value_blink
+    color: "#ff9800"
+  - condition: above
+    value: 32
+    effect: shadow_pulse
+    color: "#f44336"
+    duration: 600
+    intensity: 0.15
+
+# Warn when a thermostat's target temperature drifts out of a comfort band
+alarms:
+  - entity: climate.living_room
+    attribute: temperature
+    condition: outside
+    min: 18
+    max: 23
+    effect: border_pulse
+
+# Warn when the sensor stops reporting
+alarms:
+  - condition: unavailable
+    effect: value_blink
+    color: "#9e9e9e"
+    duration: 2000
+```
+
+**Migrating from `center_shadow_pulse`**
+
+The old keys keep working — they are silently converted into a single alarm, so no existing
+configuration breaks. `alarms:` takes precedence when both are present, and opening the card in
+the visual editor and touching the alarm section rewrites the old keys into the new format.
+
+```yaml
+# Before (still supported)
+center_shadow_pulse: true
+center_shadow_pulse_min: 0
+center_shadow_pulse_max: 750
+center_shadow_pulse_duration: 1500
+center_shadow_pulse_intensity: 0.3
+
+# After
+alarms:
+  - condition: range
+    min: 0
+    max: 750
+    effect: shadow_pulse
+    duration: 1500
+    intensity: 0.3
+```
 
 ### Background Transparency
 
@@ -778,11 +922,12 @@ center_shadow_blur: 35
 center_shadow_spread: 12
 
 # Alarm when temperature is too high (>28°C)
-center_shadow_pulse: true
-center_shadow_pulse_duration: 1200     # Moderately fast pulsation
-center_shadow_pulse_min: 28            # Alarm starts at 28°C
-center_shadow_pulse_max: 35            # Alarm until max
-center_shadow_pulse_intensity: 0.4     # Deep pulsation effect
+alarms:
+  - condition: above
+    value: 28
+    effect: shadow_pulse
+    duration: 1200                     # Moderately fast pulsation
+    intensity: 0.4                     # Deep pulsation effect
 
 severity:
   - color: "#00bfff"    # Blue
@@ -840,11 +985,19 @@ center_shadow_blur: 30
 center_shadow_spread: 8
 
 # Alarm when battery is critically low (<15%)
-center_shadow_pulse: true
-center_shadow_pulse_duration: 800      # Fast pulsation for urgency
-center_shadow_pulse_min: 0             # Alarm from 0%
-center_shadow_pulse_max: 15            # Alarm until 15%
-center_shadow_pulse_intensity: 0.2     # Very pronounced pulsation
+alarms:
+  - condition: below
+    value: 15
+    effect: shadow_pulse
+    duration: 800                      # Fast pulsation for urgency
+    intensity: 0.2                     # Very pronounced pulsation
+  # Bonus: blink the LEDs while the battery is actually discharging,
+  # driven by a second entity
+  - entity: sensor.battery_power
+    condition: below
+    value: 0
+    effect: leds_blink
+    duration: 900
 
 zones:
   - from: 0
@@ -1101,11 +1254,13 @@ zones:
     opacity: 0.2
 
 # Optional: Alarm when too cold
-center_shadow_pulse: true
-center_shadow_pulse_duration: 1500
-center_shadow_pulse_min: -20
-center_shadow_pulse_max: -5
-center_shadow_pulse_intensity: 0.3
+alarms:
+  - condition: range
+    min: -20
+    max: -5
+    effect: shadow_pulse
+    duration: 1500
+    intensity: 0.3
 ```
 
 **How this works:**
@@ -1135,11 +1290,13 @@ center_shadow_blur: 40
 center_shadow_spread: 10
 
 # Pulsating alarm when level is critically low (0-500L)
-center_shadow_pulse: true
-center_shadow_pulse_duration: 1500      # Slow pulsation for critical alert
-center_shadow_pulse_min: 0              # Start of alarm zone
-center_shadow_pulse_max: 500            # End of alarm zone
-center_shadow_pulse_intensity: 0.2      # Deep pulsation (20% to 100%)
+alarms:
+  - condition: range
+    min: 0                              # Start of alarm zone
+    max: 500                            # End of alarm zone
+    effect: shadow_pulse
+    duration: 1500                      # Slow pulsation for critical alert
+    intensity: 0.2                      # Deep pulsation (20% to 100%)
 
 # Severity colors - uses REAL sensor values (0-3000L)
 severity:
@@ -1172,7 +1329,7 @@ buttons:
 
 **How the pulsating alarm works:**
 - When the water level is between 0-500L (critical zone), the center shadow pulses
-- **Important:** `pulse_min` and `pulse_max` use the **real sensor values** (0-3000L in this example), not percentages
+- **Important:** `min` and `max` use the **real sensor values** (0-3000L in this example), not percentages
 - The pulsation combines intensity and opacity changes for maximum visibility
 - Duration of 1500ms creates a noticeable but not annoying effect
 - Intensity of 0.2 means the shadow varies from 20% to 100% strength
@@ -1183,20 +1340,26 @@ buttons:
 # For a tank with 0-3000L range, alarm when critically low (0-500L)
 min: 0
 max: 3000
-center_shadow_pulse_min: 0      # Alarm starts at 0 liters
-center_shadow_pulse_max: 500    # Alarm stops at 500 liters
+alarms:
+  - condition: below
+    value: 500                  # Alarm below 500 liters
+    effect: shadow_pulse
 
 # For a temperature sensor (-10 to 40°C), alarm when too hot (>30°C)
 min: -10
 max: 40
-center_shadow_pulse_min: 30     # Alarm starts at 30°C
-center_shadow_pulse_max: 40     # Alarm until maximum
+alarms:
+  - condition: above
+    value: 30                   # Alarm above 30°C
+    effect: shadow_pulse
 
 # For a battery (0-100%), alarm when low (<20%)
 min: 0
 max: 100
-center_shadow_pulse_min: 0      # Alarm at 0%
-center_shadow_pulse_max: 20     # Alarm until 20%
+alarms:
+  - condition: below
+    value: 20                   # Alarm below 20%
+    effect: shadow_pulse
 ```
 
 ## Compatibility

--- a/card.yaml
+++ b/card.yaml
@@ -26,12 +26,24 @@ enable_shadow: true
 center_shadow: true
 center_shadow_blur: 30
 center_shadow_spread: 5
-# Configuration de l'alarme visuelle par pulsation du center_shadow
-center_shadow_pulse: true              # Active la pulsation (défaut: false)
-center_shadow_pulse_duration: 1500     # Durée d'un cycle complet en ms (défaut: 1000)
-center_shadow_pulse_min: 0             # Valeur minimale zone alarme en VALEURS REELLES (ici 0L, défaut: min)
-center_shadow_pulse_max: 750           # Valeur maximale zone alarme en VALEURS REELLES (ici 750L, défaut: max)
-center_shadow_pulse_intensity: 0.3     # Intensité minimale de la pulsation 0-1 (défaut: 0.5)
+# Alarmes (v2.2) — chaque alarme surveille une entité et applique un effet visuel
+# tant que sa condition est vraie. Les anciennes clés center_shadow_pulse_* restent
+# supportées et sont converties automatiquement en une alarme.
+alarms:
+  # Alarme sur l'entité de la jauge : cuve basse (VALEURS REELLES, ici des litres)
+  - condition: range                   # range | outside | above | below | equal | state | state_not | unavailable
+    min: 0
+    max: 750
+    effect: shadow_pulse               # shadow_pulse | leds_blink | value_blink | border_pulse
+    duration: 1500                     # durée d'un cycle complet en ms (défaut: 1000)
+    intensity: 0.3                     # creux du cycle 0-1 (défaut: 0.5)
+  # Alarme sur une AUTRE entité : halo rouge autour de la carte en cas de défaut pompe
+  - entity: binary_sensor.defaut_pompe
+    condition: state
+    state: "on"
+    effect: border_pulse
+    color: "#f44336"                   # optionnel — sinon la couleur severity de la jauge
+    name: Défaut pompe                 # optionnel — libellé dans l'éditeur visuel
 show_trend: true
 markers:
   - value: 1000

--- a/custom-gauge-card.js
+++ b/custom-gauge-card.js
@@ -1,7 +1,14 @@
 /**
- * Custom Gauge Card v2.0.0
+ * Custom Gauge Card v2.2.0
  * Home Assistant custom card — LED gauge with arc control, bidirectional mode,
  * scale ticks, 4 buttons and full shadow support.
+ *
+ * Changelog v2.2 vs v2.1:
+ *   - NEW  alarms: [] — multiple alarms, each watching any entity (not just the
+ *          gauge entity), with 8 condition types and 4 visual effects
+ *   - NEW  alarm effects: shadow_pulse, leds_blink, value_blink, border_pulse
+ *   - NEW  per-alarm color override
+ *   - KEEP center_shadow_pulse* still works — silently migrated to alarms[0]
  *
  * Changelog v2.0 vs v1.0.5:
  *   - NEW  arc_sweep (30–360°) + arc_start — full YAML control
@@ -17,7 +24,7 @@
 !function () {
   "use strict";
 
-  const CARD_VERSION = '2.1.0';
+  const CARD_VERSION = '2.2.0';
 
   // ── Themes ──────────────────────────────────────────────────────────────────
   const THEMES = {
@@ -54,6 +61,14 @@
 .switch-button.top-right{top:30px;right:30px}
 .switch-button.bottom-left{bottom:40px;left:30px}
 .switch-button.bottom-right{bottom:40px;right:30px}
+@keyframes cgc-alarm-blink{0%,100%{opacity:1}50%{opacity:var(--cgc-blink-min,.25)}}
+@keyframes cgc-alarm-border{0%,100%{box-shadow:0 0 6px 0 var(--alarm-border-color,#f44336)}50%{box-shadow:0 0 24px 7px var(--alarm-border-color,#f44336)}}
+.gauge-card.alarm-leds .led.active{--cgc-blink-min:var(--alarm-leds-opacity,.25);animation:cgc-alarm-blink var(--alarm-leds-duration,1s) ease-in-out infinite}
+.gauge-card.alarm-value .value,.gauge-card.alarm-value .unit{--cgc-blink-min:var(--alarm-value-opacity,.25);animation:cgc-alarm-blink var(--alarm-value-duration,1s) ease-in-out infinite}
+.gauge-card.alarm-value .value{color:var(--alarm-value-color,var(--value-font-color))}
+.gauge-card.alarm-value .unit{color:var(--alarm-value-color,var(--unit-font-color))}
+.gauge-card.alarm-border{animation:cgc-alarm-border var(--alarm-border-duration,1s) ease-in-out infinite}
+@media (prefers-reduced-motion:reduce){.gauge-card.alarm-leds .led.active,.gauge-card.alarm-value .value,.gauge-card.alarm-value .unit,.gauge-card.alarm-border{animation-duration:2.5s}}
 `;
 
   // ── Utilities ────────────────────────────────────────────────────────────────
@@ -80,11 +95,18 @@
     return '#555';
   }
 
+  /**
+   * #rrggbb / #rgb → rgba(). Any other notation (named color, rgb(), var(...))
+   * is returned untouched: the pulsation then varies blur/spread only.
+   */
   function hexToRgba(hex, alpha) {
-    const r = parseInt(hex.slice(1, 3), 16);
-    const g = parseInt(hex.slice(3, 5), 16);
-    const b = parseInt(hex.slice(5, 7), 16);
-    if (isNaN(r) || isNaN(g) || isNaN(b)) return hex;
+    if (typeof hex !== 'string') return hex;
+    let h = hex.trim();
+    if (h.length === 4 && h[0] === '#') h = `#${h[1]}${h[1]}${h[2]}${h[2]}${h[3]}${h[3]}`;
+    if (!/^#[0-9a-fA-F]{6}$/.test(h)) return hex;
+    const r = parseInt(h.slice(1, 3), 16);
+    const g = parseInt(h.slice(3, 5), 16);
+    const b = parseInt(h.slice(5, 7), 16);
     return `rgba(${r},${g},${b},${alpha.toFixed(3)})`;
   }
 
@@ -134,6 +156,129 @@
       const frac = lowerRange > 0 ? (refPoint - value) / lowerRange : 0;
       return refAngle - frac * arcSweep * zeroFrac;
     }
+  }
+
+  // ── Alarms ───────────────────────────────────────────────────────────────────
+
+  const ALARM_CONDITIONS = ['range', 'outside', 'above', 'below', 'equal', 'state', 'state_not', 'unavailable'];
+  const ALARM_EFFECTS    = ['shadow_pulse', 'leds_blink', 'value_blink', 'border_pulse'];
+
+  // CSS-driven effects: class toggled on .gauge-card, parameters passed as CSS vars.
+  // shadow_pulse is absent here — it is driven in JS because it follows the live
+  // severity color of the gauge when no explicit alarm color is set.
+  const ALARM_CSS_EFFECTS = {
+    leds_blink:   { cls: 'alarm-leds',   ns: 'leds'   },
+    value_blink:  { cls: 'alarm-value',  ns: 'value'  },
+    border_pulse: { cls: 'alarm-border', ns: 'border' },
+  };
+
+  const LEGACY_PULSE_KEYS = [
+    'center_shadow_pulse', 'center_shadow_pulse_min', 'center_shadow_pulse_max',
+    'center_shadow_pulse_duration', 'center_shadow_pulse_intensity',
+  ];
+
+  function normalizeAlarm(a, config) {
+    const num = (v, fallback) => (v !== undefined && v !== null && v !== '' && !isNaN(Number(v)) ? Number(v) : fallback);
+    return {
+      name:      a.name || null,
+      entity:    a.entity || null,                 // null → the gauge entity
+      attribute: a.attribute || null,
+      condition: ALARM_CONDITIONS.includes(a.condition) ? a.condition : 'range',
+      min:       num(a.min, num(config.min, 0)),
+      max:       num(a.max, num(config.max, 100)),
+      value:     num(a.value, 0),
+      state:     a.state !== undefined && a.state !== null ? String(a.state) : 'on',
+      effect:    ALARM_EFFECTS.includes(a.effect) ? a.effect : 'shadow_pulse',
+      color:     a.color || null,                  // null → severity color of the gauge
+      duration:  Math.max(100, num(a.duration, 1000)),
+      intensity: Math.max(0, Math.min(1, num(a.intensity, 0.5))),
+    };
+  }
+
+  /** Legacy center_shadow_pulse_* → a single alarm. Returns null when disabled. */
+  function legacyPulseAlarm(config) {
+    if (!config.center_shadow_pulse) return null;
+    return {
+      condition: 'range',
+      min:       config.center_shadow_pulse_min,
+      max:       config.center_shadow_pulse_max,
+      effect:    'shadow_pulse',
+      duration:  config.center_shadow_pulse_duration,
+      intensity: config.center_shadow_pulse_intensity,
+    };
+  }
+
+  /** alarms: [] wins over the legacy keys; both are supported. */
+  function buildAlarms(config) {
+    if (Array.isArray(config.alarms)) {
+      return config.alarms
+        .filter(a => a && typeof a === 'object')
+        .map(a => normalizeAlarm(a, config));
+    }
+    const legacy = legacyPulseAlarm(config);
+    return legacy ? [normalizeAlarm(legacy, config)] : [];
+  }
+
+  function isAlarmActive(ctx, alarm) {
+    const hass = ctx._hass;
+    if (!hass) return false;
+    const entityId = alarm.entity || ctx.config.entity;
+    const st = hass.states[entityId];
+    if (!st) return alarm.condition === 'unavailable';
+
+    const raw = alarm.attribute ? st.attributes[alarm.attribute] : st.state;
+    const unavailable = raw === undefined || raw === null || raw === 'unavailable' || raw === 'unknown';
+
+    switch (alarm.condition) {
+      case 'unavailable': return unavailable;
+      case 'state':       return String(raw) === alarm.state;
+      case 'state_not':   return String(raw) !== alarm.state;
+    }
+    if (unavailable) return false;
+
+    const v = parseFloat(raw);
+    if (isNaN(v)) return false;
+    switch (alarm.condition) {
+      case 'above':   return v >  alarm.value;
+      case 'below':   return v <  alarm.value;
+      case 'equal':   return v === alarm.value;
+      case 'outside': return v <  alarm.min || v > alarm.max;
+      default:        return v >= alarm.min && v <= alarm.max;   // range
+    }
+  }
+
+  /**
+   * Re-evaluate every alarm and apply the matching effects.
+   * Called on every hass update — including when the gauge entity itself did not
+   * change — so an alarm can watch any other entity.
+   */
+  function evaluateAlarms(ctx) {
+    if (!ctx.shadowRoot || !ctx._hass) return;
+    const card = ctx.shadowRoot.getElementById('gauge-container');
+    if (!card) return;
+
+    const alarms = ctx.config.alarms || [];
+    const active = alarms.filter(a => isAlarmActive(ctx, a));
+    ctx.activeAlarms = active;
+
+    for (const [effect, { cls, ns }] of Object.entries(ALARM_CSS_EFFECTS)) {
+      const a = active.find(x => x.effect === effect);
+      card.classList.toggle(cls, !!a);
+      if (!a) continue;
+      card.style.setProperty(`--alarm-${ns}-duration`, `${a.duration}ms`);
+      card.style.setProperty(`--alarm-${ns}-opacity`,  String(a.intensity));
+      if (a.color) card.style.setProperty(`--alarm-${ns}-color`, a.color);
+      else         card.style.removeProperty(`--alarm-${ns}-color`);
+    }
+
+    updateShadowPulse(ctx, active.find(a => a.effect === 'shadow_pulse') || null);
+  }
+
+  function clearAlarmEffects(ctx) {
+    const card = ctx.shadowRoot?.getElementById('gauge-container');
+    if (card) Object.values(ALARM_CSS_EFFECTS).forEach(({ cls }) => card.classList.remove(cls));
+    ctx.activeAlarms = [];
+    updateShadowPulse(ctx, null);
   }
 
   // ── Config ───────────────────────────────────────────────────────────────────
@@ -193,6 +338,9 @@
     if (config.show_switch_button && config.switch_entity && c.buttons.length === 0) {
       c.buttons = [{ entity: config.switch_entity, position: config.switch_button_position || 'bottom-right', icon: null }];
     }
+    // v2.2: alarms — normalized here so the render path never sees raw user input.
+    // Built from `c` (not `config`) so the legacy pulse keys are already defaulted.
+    c.alarms = buildAlarms(c);
     return c;
   }
 
@@ -242,35 +390,63 @@
     ctx.intersectionObserver = new IntersectionObserver(entries => {
       entries.forEach(e => {
         ctx.isVisible = e.isIntersecting;
-        if (ctx.isVisible && ctx._hass && ctx._updateGauge) ctx._updateGauge();
+        if (ctx.isVisible) {
+          if (ctx._hass && ctx._updateGauge) ctx._updateGauge();
+          if (ctx._evaluateAlarms) ctx._evaluateAlarms();
+        } else {
+          // Off-screen: drop the animations too, that is the point of power save.
+          clearAlarmEffects(ctx);
+        }
       });
     }, { root: null, rootMargin: '0px', threshold: ctx.config.power_save_threshold / 100 });
     ctx.intersectionObserver.observe(ctx);
   }
 
-  function startCenterShadowPulsation(ctx, value, min, max) {
-    if (!ctx.config.center_shadow_pulse) return;
-    const inZone = value >= ctx.config.center_shadow_pulse_min && value <= ctx.config.center_shadow_pulse_max;
-    if (inZone && !ctx.pulsationInterval) {
-      const dur        = ctx.config.center_shadow_pulse_duration || 1000;
-      const intensity  = ctx.config.center_shadow_pulse_intensity;
-      const baseBlur   = ctx.config.center_shadow_blur   || 30;
-      const baseSpread = ctx.config.center_shadow_spread || 15;
-      const t0         = Date.now();
-      ctx.pulsationInterval = setInterval(() => {
-        const wave = Math.sin(((Date.now() - t0) % dur) / dur * Math.PI * 2) * 0.5 + 0.5;
-        const mult = intensity + (1 - intensity) * wave;
-        const cs   = ctx.shadowRoot?.getElementById('center-shadow');
-        if (cs && ctx.currentShadowColor) {
-          const c = hexToRgba(ctx.currentShadowColor, mult);
-          cs.style.boxShadow = `0 0 ${(baseBlur * mult).toFixed(1)}px ${(baseSpread * mult).toFixed(1)}px ${c}`;
-        }
-      }, 16);
-    } else if (!inZone && ctx.pulsationInterval) {
-      clearInterval(ctx.pulsationInterval);
-      ctx.pulsationInterval = null;
-      if (ctx._updateCenterShadow) ctx._updateCenterShadow(((value - min) / (max - min)) * 100, value, min, max);
+  /**
+   * Start/stop/retune the center-shadow pulsation from an alarm (or null to stop).
+   * The interval is only restarted when the pulse parameters actually change, so a
+   * hass update every second does not reset the wave.
+   */
+  function updateShadowPulse(ctx, alarm) {
+    const sig = alarm ? `${alarm.duration}|${alarm.intensity}|${alarm.color || ''}` : null;
+    if (sig === ctx.pulsationSig) return;
+    ctx.pulsationSig = sig;
+    stopCenterShadowPulsation(ctx);
+    if (alarm) { startCenterShadowPulsation(ctx, alarm); return; }
+    // Back to the static shadow — or none at all when center_shadow is off.
+    const cs = ctx.shadowRoot?.getElementById('center-shadow');
+    if (!cs) return;
+    cs.style.transition = '';
+    if (ctx.config.center_shadow && ctx.currentShadowColor) {
+      const blur   = ctx.config.center_shadow_blur   || 30;
+      const spread = ctx.config.center_shadow_spread || 15;
+      cs.style.boxShadow = `0 0 ${blur}px ${spread}px ${ctx.currentShadowColor}`;
+    } else {
+      cs.style.boxShadow = 'none';
     }
+  }
+
+  function startCenterShadowPulsation(ctx, alarm) {
+    const dur        = alarm.duration;
+    const intensity  = alarm.intensity;
+    const baseBlur   = ctx.config.center_shadow_blur   || 30;
+    const baseSpread = ctx.config.center_shadow_spread || 15;
+    const t0         = Date.now();
+    // The .center-shadow CSS transition (300 ms) would lag behind a 16 ms tick and
+    // never let the shadow reach its target color — the wave is the animation here.
+    const csEl = ctx.shadowRoot?.getElementById('center-shadow');
+    if (csEl) csEl.style.transition = 'none';
+    ctx.pulsationInterval = setInterval(() => {
+      const wave  = Math.sin(((Date.now() - t0) % dur) / dur * Math.PI * 2) * 0.5 + 0.5;
+      const mult  = intensity + (1 - intensity) * wave;
+      const cs    = ctx.shadowRoot?.getElementById('center-shadow');
+      // Falls back to the live severity color, re-read each tick so the pulse
+      // follows the gauge color when no explicit alarm color is configured.
+      const color = alarm.color || ctx.currentShadowColor;
+      if (cs && color) {
+        cs.style.boxShadow = `0 0 ${(baseBlur * mult).toFixed(1)}px ${(baseSpread * mult).toFixed(1)}px ${hexToRgba(color, mult)}`;
+      }
+    }, 16);
   }
 
   function stopCenterShadowPulsation(ctx) {
@@ -420,7 +596,7 @@
     const csBlur   = config.center_shadow_blur   || 30;
     const csSpread = config.center_shadow_spread  || 15;
     const csColor  = (Array.isArray(config.severity) && config.severity[0]?.color) || '#4caf50';
-    const csPreview = (config.center_shadow || config.center_shadow_pulse)
+    const csPreview = config.center_shadow
       ? `0 0 ${csBlur}px ${csSpread}px ${csColor}`
       : 'none';
     return `
@@ -656,8 +832,10 @@
 
   function updateCenterShadow(ctx, value, realValue, min, max) {
     const cs = ctx.shadowRoot.getElementById('center-shadow');
-    if (!ctx.config.center_shadow && !ctx.config.center_shadow_pulse) {
-      stopCenterShadowPulsation(ctx);
+    // The shadow is also needed when an alarm pulses it, even with center_shadow off.
+    const pulsable = (ctx.config.alarms || []).some(a => a.effect === 'shadow_pulse');
+    if (!ctx.config.center_shadow && !pulsable) {
+      updateShadowPulse(ctx, null);
       if (cs) cs.style.boxShadow = 'none';
       return;
     }
@@ -665,9 +843,9 @@
     const blur   = ctx.config.center_shadow_blur   || 30;
     const spread = ctx.config.center_shadow_spread || 15;
     ctx.currentShadowColor = color;
-    if (cs && !ctx.pulsationInterval) cs.style.boxShadow = `0 0 ${blur}px ${spread}px ${color}`;
-    if (ctx.config.center_shadow_pulse && realValue !== undefined) {
-      startCenterShadowPulsation(ctx, realValue, min, max);
+    // While pulsing, the pulsation interval owns the box-shadow.
+    if (cs && !ctx.pulsationInterval) {
+      cs.style.boxShadow = ctx.config.center_shadow ? `0 0 ${blur}px ${spread}px ${color}` : 'none';
     }
   }
 
@@ -743,7 +921,9 @@
       // Only rebuild when a key that controls section visibility changes.
       // Compare against _builtConfig (snapshot at last _build), not _config,
       // because _change() updates _config immediately before HA calls setConfig.
-      const STRUCTURAL = ['theme', 'center_shadow', 'center_shadow_pulse', 'entity'];
+      // `alarms` is deliberately absent: the alarms editor redraws itself, a full
+      // rebuild on every keystroke would steal focus.
+      const STRUCTURAL = ['theme', 'center_shadow', 'entity'];
       if (STRUCTURAL.some(k => (this._builtConfig || {})[k] !== config[k])) this._build();
     }
 
@@ -902,6 +1082,221 @@
       return wrap;
     }
 
+    /**
+     * Write the alarms list to the config and drop the legacy pulse keys so a
+     * migrated card never carries two sources of truth.
+     */
+    _commitAlarms(alarms) {
+      const cfg = { ...this._config, alarms: alarms.map(a => ({ ...a })) };
+      LEGACY_PULSE_KEYS.forEach(k => delete cfg[k]);
+      this._config = cfg;
+      this.dispatchEvent(new CustomEvent('config-changed', {
+        detail: { config: cfg }, bubbles: true, composed: true,
+      }));
+    }
+
+    /**
+     * ha-selector bound to one key of one alarm.
+     * No data-key attribute: the `set hass` re-sync loop only re-syncs top-level
+     * config keys and would otherwise overwrite this value with the whole array.
+     */
+    _alarmSel(alarms, idx, key, selector, label, defaultVal, onChange) {
+      const wrap = document.createElement('div');
+      wrap.className = 'field';
+      if (label) {
+        const lbl = document.createElement('label');
+        lbl.className = 'field-label';
+        lbl.textContent = label;
+        wrap.appendChild(lbl);
+      }
+      const el = document.createElement('ha-selector');
+      el.setAttribute('data-sel', '');
+      el.selector = selector;
+      const cur = alarms[idx][key];
+      el.value = cur !== undefined && cur !== null ? cur : (defaultVal !== undefined ? defaultVal : '');
+      if (this._hass) el.hass = this._hass;
+      el.addEventListener('value-changed', e => {
+        e.stopPropagation();
+        const v = e.detail.value;
+        alarms[idx][key] = (v === '' || v === undefined) ? null : v;
+        this._commitAlarms(alarms);
+        if (onChange) onChange();
+      });
+      wrap.appendChild(el);
+      return wrap;
+    }
+
+    _alarmColorField(alarms, idx) {
+      const wrap = document.createElement('div');
+      wrap.className = 'field';
+      const lbl = document.createElement('label');
+      lbl.className = 'field-label';
+      lbl.textContent = 'Color';
+      wrap.appendChild(lbl);
+
+      const row = document.createElement('div');
+      row.className = 'color-field-row';
+      const cur   = alarms[idx].color || '';
+      const isHex = /^#[0-9a-fA-F]{6}$/.test(cur);
+
+      const picker = document.createElement('input');
+      picker.type = 'color';
+      picker.value = isHex ? cur : '#f44336';
+      picker.className = 'color-field-picker';
+      picker.title = 'Choose an alarm color';
+
+      const valTxt = document.createElement('span');
+      valTxt.className = 'color-field-val';
+      valTxt.textContent = cur || '(gauge color)';
+
+      const clearBtn = document.createElement('button');
+      clearBtn.textContent = '✕';
+      clearBtn.className = 'color-field-clear';
+      clearBtn.title = 'Reset (follow the gauge severity color)';
+      clearBtn.style.visibility = cur ? 'visible' : 'hidden';
+
+      picker.addEventListener('input', e => {
+        valTxt.textContent = e.target.value;
+        clearBtn.style.visibility = 'visible';
+        alarms[idx].color = e.target.value;
+        this._commitAlarms(alarms);
+      });
+      clearBtn.addEventListener('click', () => {
+        picker.value = '#f44336';
+        valTxt.textContent = '(gauge color)';
+        clearBtn.style.visibility = 'hidden';
+        alarms[idx].color = null;
+        this._commitAlarms(alarms);
+      });
+
+      row.append(picker, valTxt, clearBtn);
+      wrap.appendChild(row);
+      return wrap;
+    }
+
+    _buildAlarmsEditor() {
+      const wrap = document.createElement('div');
+      wrap.className = 'alarms-editor';
+
+      // Seed from `alarms`, falling back to the legacy center_shadow_pulse_* keys
+      // so an existing card opens in the editor with its alarm already listed.
+      let alarms;
+      if (Array.isArray(this._config.alarms)) {
+        alarms = this._config.alarms.map(a => ({ ...a }));
+      } else {
+        const legacy = legacyPulseAlarm(this._config);
+        alarms = legacy ? [legacy] : [];
+      }
+
+      const CONDITIONS = [
+        { value: 'range',       label: 'Value between min and max' },
+        { value: 'outside',     label: 'Value outside min…max' },
+        { value: 'above',       label: 'Value above' },
+        { value: 'below',       label: 'Value below' },
+        { value: 'equal',       label: 'Value equals' },
+        { value: 'state',       label: 'State is' },
+        { value: 'state_not',   label: 'State is not' },
+        { value: 'unavailable', label: 'Entity unavailable' },
+      ];
+      const EFFECTS = [
+        { value: 'shadow_pulse', label: 'Pulsating center shadow' },
+        { value: 'leds_blink',   label: 'Blinking LEDs' },
+        { value: 'value_blink',  label: 'Blinking value' },
+        { value: 'border_pulse', label: 'Pulsating card border' },
+      ];
+
+      const redraw = () => {
+        wrap.innerHTML = '';
+
+        alarms.forEach((alarm, idx) => {
+          const box = document.createElement('div');
+          box.className = 'alarm-box';
+
+          const head = document.createElement('div');
+          head.className = 'alarm-head';
+          const title = document.createElement('span');
+          title.textContent = alarm.name || `Alarm ${idx + 1}`;
+          const delBtn = document.createElement('button');
+          delBtn.textContent = '✕';
+          delBtn.className = 'alarm-del';
+          delBtn.title = 'Delete this alarm';
+          delBtn.addEventListener('click', () => {
+            alarms.splice(idx, 1);
+            this._commitAlarms(alarms);
+            redraw();
+          });
+          head.append(title, delBtn);
+          box.appendChild(head);
+
+          // redraw: picking an entity reveals its attribute selector
+          box.appendChild(this._alarmSel(alarms, idx, 'entity', { entity: {} },
+            'Watched entity (empty = gauge entity)', undefined, redraw));
+
+          if (alarm.entity) {
+            box.appendChild(this._alarmSel(alarms, idx, 'attribute',
+              { attribute: { entity_id: alarm.entity } }, 'Attribute (optional)'));
+          }
+
+          box.appendChild(this._row(2,
+            this._alarmSel(alarms, idx, 'condition', { select: { options: CONDITIONS, mode: 'dropdown' } },
+              'Condition', 'range', redraw),
+            this._alarmSel(alarms, idx, 'effect', { select: { options: EFFECTS, mode: 'dropdown' } },
+              'Effect', 'shadow_pulse', redraw),
+          ));
+
+          const cond = alarm.condition || 'range';
+          if (cond === 'range' || cond === 'outside') {
+            box.appendChild(this._row(2,
+              this._alarmSel(alarms, idx, 'min', { number: { mode: 'box', step: 'any' } }, 'Min value'),
+              this._alarmSel(alarms, idx, 'max', { number: { mode: 'box', step: 'any' } }, 'Max value'),
+            ));
+          } else if (cond === 'above' || cond === 'below' || cond === 'equal') {
+            box.appendChild(this._alarmSel(alarms, idx, 'value',
+              { number: { mode: 'box', step: 'any' } }, 'Threshold value'));
+          } else if (cond === 'state' || cond === 'state_not') {
+            box.appendChild(this._alarmSel(alarms, idx, 'state', { text: {} }, 'State (e.g. on, off, charging)', 'on'));
+          }
+
+          box.appendChild(this._row(2,
+            this._alarmSel(alarms, idx, 'duration',
+              { number: { min: 200, max: 5000, step: 100, mode: 'box', unit_of_measurement: 'ms' } }, 'Cycle duration', 1000),
+            this._alarmSel(alarms, idx, 'intensity',
+              { number: { min: 0, max: 1, step: 0.05, mode: 'slider' } }, 'Min intensity (0 = full flash)', 0.5),
+          ));
+
+          if (alarm.effect === 'leds_blink') {
+            box.appendChild(this._info('Blinking LEDs keep their severity colors — the color below is ignored for this effect.'));
+          }
+          box.appendChild(this._alarmColorField(alarms, idx));
+          box.appendChild(this._alarmSel(alarms, idx, 'name', { text: {} }, 'Label (optional, editor only)'));
+
+          wrap.appendChild(box);
+        });
+
+        if (!alarms.length) {
+          wrap.appendChild(this._info('No alarm configured. An alarm watches any entity and applies a visual effect while its condition is met.'));
+        }
+
+        const addBtn = document.createElement('button');
+        addBtn.textContent = '+ Add alarm';
+        addBtn.className = 'alarm-add';
+        addBtn.addEventListener('click', () => {
+          alarms.push({
+            entity: null, condition: 'range',
+            min: this._config.min !== undefined ? this._config.min : 0,
+            max: this._config.max !== undefined ? this._config.max : 100,
+            effect: 'shadow_pulse', duration: 1000, intensity: 0.5,
+          });
+          this._commitAlarms(alarms);
+          redraw();
+        });
+        wrap.appendChild(addBtn);
+      };
+
+      redraw();
+      return wrap;
+    }
+
     _buildSeverityEditor() {
       const wrap = document.createElement('div');
       wrap.className = 'severity-editor';
@@ -1018,12 +1413,18 @@
         .sev-val { height: 34px; padding: 0 10px; border: 1px solid var(--divider-color); border-radius: 6px;
                    background: var(--card-background-color, #fff); color: var(--primary-text-color);
                    font-size: 14px; width: 100%; box-sizing: border-box; }
-        .sev-del { width: 32px; height: 32px; border-radius: 50%; border: none;
+        .sev-del, .alarm-del { width: 32px; height: 32px; border-radius: 50%; border: none;
                    background: var(--error-color, #f44336); color: white;
                    cursor: pointer; font-size: 14px; line-height: 1; }
-        .sev-add { margin-top: 4px; padding: 7px 12px; border: 1px dashed var(--primary-color);
+        .sev-add, .alarm-add { margin-top: 4px; padding: 7px 12px; border: 1px dashed var(--primary-color);
                    border-radius: 6px; background: none; color: var(--primary-color);
                    cursor: pointer; font-size: 13px; width: 100%; }
+        .alarms-editor { display: flex; flex-direction: column; gap: 10px; }
+        .alarm-box { display: flex; flex-direction: column; gap: 10px; padding: 12px;
+                     border: 1px solid var(--divider-color); border-radius: 8px; }
+        .alarm-head { display: flex; align-items: center; justify-content: space-between;
+                      font-size: 11px; font-weight: 700; color: var(--primary-color);
+                      text-transform: uppercase; letter-spacing: 0.6px; }
         .color-field-row { display: flex; align-items: center; gap: 8px; }
         .color-field-picker { width: 44px; height: 34px; padding: 2px 3px; border: 1px solid var(--divider-color);
                               border-radius: 6px; cursor: pointer; background: none; flex-shrink: 0; }
@@ -1164,23 +1565,11 @@
         this._buildSeverityEditor(),
       ));
 
-      // ── Pulsating alarm ──────────────────────────────────────────────────────
-      const alarmChildren = [];
-      if (!cfg.center_shadow) {
-        alarmChildren.push(this._info('⚠️ Enable "Center shadow" in Visual effects to use the pulsating alarm.'));
-      }
-      alarmChildren.push(this._sel('center_shadow_pulse', { boolean: {} }, 'Enable pulsating alarm', false));
-      if (cfg.center_shadow_pulse) {
-        alarmChildren.push(
-          this._row(3,
-            this._sel('center_shadow_pulse_min', { number: { mode: 'box', step: 'any' } }, 'Min trigger value'),
-            this._sel('center_shadow_pulse_max', { number: { mode: 'box', step: 'any' } }, 'Max trigger value'),
-            this._sel('center_shadow_pulse_duration', { number: { min: 200, max: 5000, step: 100, mode: 'box', unit_of_measurement: 'ms' } }, 'Cycle duration', 1000),
-          ),
-          this._sel('center_shadow_pulse_intensity', { number: { min: 0, max: 1, step: 0.05, mode: 'slider' } }, 'Minimum intensity (0 = full flash, 1 = no pulse)', 0.5),
-        );
-      }
-      root.appendChild(this._section('Pulsating alarm', ...alarmChildren));
+      // ── Alarms ───────────────────────────────────────────────────────────────
+      root.appendChild(this._section('Alarms',
+        this._info('Each alarm watches an entity — the gauge one by default, or any other — and applies a visual effect while its condition is met.'),
+        this._buildAlarmsEditor(),
+      ));
 
       // ── Scale ticks ──────────────────────────────────────────────────────────
       root.appendChild(this._section('Scale ticks',
@@ -1280,6 +1669,8 @@
       this.isVisible           = true;
       this.animationInterval   = null;
       this.pulsationInterval   = null;
+      this.pulsationSig        = null;
+      this.activeAlarms        = [];
       this.buttonsInitialized  = false;
       this.trendInitialized    = false;
 
@@ -1291,6 +1682,7 @@
       this._updateCenterShadow = updateCenterShadow.bind(null, this);
       this._updateButtonsState = updateButtonsState.bind(null, this);
       this._createButtons      = createButtons.bind(null, this);
+      this._evaluateAlarms     = evaluateAlarms.bind(null, this);
 
       this.shadowRoot
         .getElementById('gauge-container')
@@ -1315,6 +1707,7 @@
         this.trendInitialized = true;
         updateDynamicMarkers(this, this._hass);
         this._updateGauge();
+        this._evaluateAlarms();
       }
     }
 
@@ -1343,6 +1736,10 @@
       } else {
         this._updateGauge();
       }
+
+      // Alarms are never debounced: they may watch an entity other than the gauge
+      // one, and a delayed alert is a broken alert.
+      this._evaluateAlarms();
     }
 
     getCardSize() { return 4; }
@@ -1351,6 +1748,7 @@
       if (this.updateTimer)       { clearTimeout(this.updateTimer);       this.updateTimer = null; }
       if (this.animationInterval) { clearInterval(this.animationInterval); this.animationInterval = null; }
       stopCenterShadowPulsation(this);
+      this.pulsationSig = null;
       if (this.intersectionObserver) { this.intersectionObserver.disconnect(); this.intersectionObserver = null; }
     }
   }

--- a/info.md
+++ b/info.md
@@ -42,6 +42,7 @@ A modern, animated circular LED gauge card for Home Assistant.
 - 📐 **Scale Ticks** — SVG graduation overlay with major/minor ticks and value labels
 - 🖱️ **Tap Action** — Configurable click behavior (more-info, navigate, call-service, none)
 - 🎛️ **Visual Editor** — Full GUI editor with collapsible sections, no YAML required
+- 🚨 **Alarms** — Any number of alarms, each watching any entity, with four visual effects (pulsating shadow, blinking LEDs, blinking value, pulsating border)
 - 🎯 **Zones & Markers** — Colored zones, static markers, and real-time dynamic markers
 - 📊 **Trend Indicator** — 24-hour history at a glance
 - 🎮 **Multi-Button Control** — Control multiple entities with customizable buttons
@@ -99,6 +100,16 @@ severity:
     value: 28
   - color: "#f44336"
     value: 35
+alarms:
+  - condition: above
+    value: 28
+    effect: shadow_pulse
+    duration: 1200
+  - entity: binary_sensor.window_open
+    condition: state
+    state: "on"
+    effect: border_pulse
+    color: "#03a9f4"
 ```
 
 ### 🌟 Support


### PR DESCRIPTION
Replace the single center_shadow_pulse alarm with an `alarms:` list. Each alarm watches an entity — the gauge one by default, or any other — and applies a visual effect while its condition holds. Watching a second entity was the actual ask in discussion #16, previously only reachable through config-template-card.

- 8 conditions: range, outside, above, below, equal, state, state_not, unavailable, with optional `attribute` as the value source
- 4 effects: shadow_pulse (the former behavior), leds_blink, value_blink, border_pulse — several alarms can run at once, one per effect
- per-alarm color, duration and intensity
- evaluated on every state update, bypassing debounce_updates, so an alert is never delayed by the gauge's own refresh policy
- visual editor: the "Pulsating alarm" section becomes "Alarms" with add/remove rows and condition-dependent fields

The legacy center_shadow_pulse* keys are converted into a single alarm at parse time, so existing configurations are unaffected. `alarms:` wins when both are present, and editing the alarms section rewrites the old keys.

Two fixes fall out of the refactor:
- the pulsating shadow never reached its target color, because the 300 ms CSS transition on .center-shadow lagged behind the 16 ms pulse tick. Harmless while the pulse color always matched the gauge, visible as soon as an alarm sets its own color.
- shadow_pulse with center_shadow disabled used to leave a permanent static shadow; the shadow now appears only while the alarm is active.


Claude-Session: https://claude.ai/code/session_01TdKH8XVSpp9KsjBFaz6pmL